### PR TITLE
Use `data-title` in favor of `title` attribute on shadowDiv (prevent tooltip from always appearing)

### DIFF
--- a/es-runtime/src/controllers/PanelsImpl.ts
+++ b/es-runtime/src/controllers/PanelsImpl.ts
@@ -125,7 +125,7 @@ export class PanelsImpl implements Panels {
         const { outerPanel, shadowDiv, extPanel } = this.addShadowDomPanel(gridContainer, options)
         outerPanel.style.display = DISPLAY_FLEX
         if (options.title) {
-            shadowDiv.title = options.title
+            shadowDiv.setAttribute('data-title', options.title)
         }
         shadowDiv.parentElement?.classList.remove('hidden')
         setActive(shadowDiv)


### PR DESCRIPTION
The HTML title attribute is being set on each panel. IAW the spec for `title`, this puts a slightly annoying tooltip everywhere on the panel's div (see GIF). Recommend storing the title information in a `data-title` attribute that can be retrieved programmatically if needed.

![Peek 2023-05-30 12-08](https://github.com/MoebiusSolutions/extension-scaffold/assets/8836343/9d2e5850-66bb-40d6-8a5e-efbf755fddc2)

Alternatively, we can choose not to set options.title for our application. It seems like that will work and not break anything else.