### PR TITLE
add "center" to the GridState interface

### DIFF
--- a/es-runtime/src/es-api.ts
+++ b/es-runtime/src/es-api.ts
@@ -99,6 +99,7 @@ export interface GridState {
     right: PanelState
     top: PanelState
     bottom: PanelState
+    center: PanelState
 }
 
 export interface HistoryType {

--- a/es-runtime/src/test-page.ts
+++ b/es-runtime/src/test-page.ts
@@ -11,7 +11,8 @@ async function loadExtensions() {
     left: { activeId: "ext.example.rollup", size: '300px', isShown: true, isExpanded: false },
     right: { activeId: "ext.example.webpack", size: '300px', isShown: true, isExpanded: false },
     top: { activeId: null, size: '', isShown: false, isExpanded: false },
-    bottom: { activeId: null, size: '170px', isShown: false, isExpanded: false }
+    bottom: { activeId: null, size: '170px', isShown: false, isExpanded: false },
+    center: { activeId: null, size: '', isShown: false, isExpanded: false }
   }
 
   const urls = ['http://localhost:9091/dist/ext-react-snowpack.js',

--- a/es-runtime/src/utils.ts
+++ b/es-runtime/src/utils.ts
@@ -105,7 +105,7 @@ export const setActive = (div: HTMLDivElement) => div.classList.add('active')
 
 export const setInactive = (div: HTMLDivElement) => div.classList.remove('active')
 
-export function getLocationdState(loc: string): PanelState {
+export function getLocationState(loc: string): PanelState {
     const d = document.querySelector(`.${loc}`)
     if (d !== null) {
         //@ts-ignore
@@ -203,13 +203,15 @@ export function applyGridState(gridstate: GridState) {
 export function getGridState(): GridState {
     const gridstate: GridState = {
         left: { size: '0px', activeId: null, isShown: false, isExpanded: false }, right: { size: '0px', activeId: null, isShown: false, isExpanded: false },
-        top: { size: '0px', activeId: null, isShown: false, isExpanded: false }, bottom: { size: '0px', activeId: null, isShown: false, isExpanded: false }
+        top: { size: '0px', activeId: null, isShown: false, isExpanded: false }, bottom: { size: '0px', activeId: null, isShown: false, isExpanded: false },
+        center: { size: '0px', activeId: null, isShown: false, isExpanded: false }
     }
     const curGridstate = fromStorage('gridstate') as GridState
-    gridstate.left = getLocationdState('left')
-    gridstate.right = getLocationdState('right')
-    gridstate.top = getLocationdState('top')
-    gridstate.bottom = getLocationdState('bottom')
+    gridstate.left = getLocationState('left')
+    gridstate.right = getLocationState('right')
+    gridstate.top = getLocationState('top')
+    gridstate.bottom = getLocationState('bottom')
+    gridstate.center = getLocationState('center')
     checkForShownChange(curGridstate, gridstate)
     toStorage('gridstate', gridstate)
     return gridstate


### PR DESCRIPTION
The `GridState` interface was missing the `center` property. This was causing issues when an application was using the gridState object to calculate panel sizes, and because `center` was missing, the center panel was getting resized to 0, effectively hiding it.