### PR TITLE
Prevent restoring of maximized panels when showing a modal

### DIFF
--- a/es-runtime/src/controllers/PanelsImpl.ts
+++ b/es-runtime/src/controllers/PanelsImpl.ts
@@ -164,14 +164,14 @@ export class PanelsImpl implements Panels {
             this.focusPopOut(id)
             return true
         }
-        // Restore any maximized center
-        document.querySelectorAll('.grid-maximized .shadow-div.active').forEach(el => {
-            this.restorePanel(el.id)
-        })
         return withPanel(id, (parent, div) => {
             const wasHidden = !isActive(div)
             const location = locationFromDiv(parent)
             if (!isDialog(location)) {
+                // Restore any maximized panels
+                document.querySelectorAll('.grid-maximized .shadow-div.active').forEach(el => {
+                    this.restorePanel(el.id)
+                })
                 hidePanelsWithLocation(location)
             }
             switch (location) {


### PR DESCRIPTION
An application was experiencing an issue where if a panel was maximized, the panel would be automatically restored when a modal window is being shown.

This change proposes that this only happen if the panel being shown is not a dialog. When you show a dialog, there's an expectation that the panels behind the dialog remain in the same position. So I just moved the code that restores the maximized panels into the `!isDialog(location)` check that was already happening in the withPanel function.

Now, when you open a dialog, the panel that was maximized stays maximized. And when you open a non-modal panel, the maximized panel is restored to normal size