### PR TITLE
add ribbon bar implementation for extenstion

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -432,25 +432,31 @@ importers:
       '@types/chai': ^4.3.0
       '@types/events': ~3.0.0
       '@types/mocha': ^8.2.3
+      '@types/react': ~17.0.3
       '@types/snowpack-env': ~2.3.4
       '@web/test-runner': ~0.13.28
       chai: ~4.3.6
       copyfiles: ^2.4.1
       events: ^3.3.0
       prettier: ^2.5.1
+      react: ^17.0.2
+      react-dom: ^17.0.2
       snowpack: ^3.8.8
       typescript: ~4.8.2
     dependencies:
       events: 3.3.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@snowpack/plugin-dotenv': 2.2.0
-      '@snowpack/plugin-react-refresh': 2.5.0
+      '@snowpack/plugin-react-refresh': 2.5.0_sfoxds7t5ydpegc3knd667wn6m
       '@snowpack/plugin-typescript': 1.2.1_typescript@4.8.4
       '@snowpack/web-test-runner-plugin': 0.2.2_lh6gjniy56kufhhoawgtdx545e
-      '@testing-library/react': 11.2.7
+      '@testing-library/react': 11.2.7_sfoxds7t5ydpegc3knd667wn6m
       '@types/chai': 4.3.4
       '@types/events': 3.0.0
       '@types/mocha': 8.2.3
+      '@types/react': 17.0.53
       '@types/snowpack-env': 2.3.4
       '@web/test-runner': 0.13.31
       chai: 4.3.7
@@ -8211,7 +8217,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0

--- a/es-extension-examples/ext-example-rollup/src/extension-entry.tsx
+++ b/es-extension-examples/ext-example-rollup/src/extension-entry.tsx
@@ -11,6 +11,26 @@ export async function activate(scaffold: ExtensionScaffoldApi) {
       </React.StrictMode>,
       div
     );
+
+    const ribbonAPI = scaffold.chrome.ribbonBar
+    // @ts-ignore
+    const viewPanel = ribbonAPI.claimRibbonSection('view.section1') as HTMLDivElement | null;
+    console.log('viewPanel', viewPanel);
+    
+    // @ts-ignore
+    const RibbonSection = ribbonAPI.components.RibbonSection as React.ReactNode
+
+    ReactDOM.render(
+      // @ts-ignore
+      <RibbonSection label={'section1'}>
+        <button onClick={() => {
+          console.log('clicked');
+        }}>
+          Click me
+        </button>
+      </RibbonSection>,
+      viewPanel
+    );
   }
 
   const span = document.createElement('span')

--- a/es-runtime/package.json
+++ b/es-runtime/package.json
@@ -21,7 +21,9 @@
     "build"
   ],
   "dependencies": {
-    "events": "^3.3.0"
+    "events": "^3.3.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@snowpack/plugin-dotenv": "~2.2.0",
@@ -38,6 +40,7 @@
     "copyfiles": "^2.4.1",
     "prettier": "^2.5.1",
     "snowpack": "^3.8.8",
-    "typescript": "~4.8.2"
+    "typescript": "~4.8.2",
+    "@types/react": "^17.0.2"
   }
 }

--- a/es-runtime/src/es-api.ts
+++ b/es-runtime/src/es-api.ts
@@ -3,6 +3,7 @@ import './theme.css'
 
 import { extensionScaffold } from './controllers/ExtensionController'
 import type { EventEmitter } from 'events'
+import type { ReactNode } from 'react';
 
 export const LOCATIONS = [
     'header',
@@ -169,7 +170,7 @@ export interface RibbonBar {
     showRibbonTab: (id: string) => HTMLDivElement | null
     hideRibbonTab: (id: string) => HTMLDivElement | null
     components?: {
-        [key: string]: HTMLElement
+        [key: string]: ReactNode;
     }
 }
 

--- a/es-runtime/src/es-api.ts
+++ b/es-runtime/src/es-api.ts
@@ -169,6 +169,7 @@ export interface RibbonBar {
     claimRibbonPanel: (id: string) => HTMLDivElement | null
     showRibbonTab: (id: string) => HTMLDivElement | null
     hideRibbonTab: (id: string) => HTMLDivElement | null
+    claimRibbonSection?: (id: string) => HTMLDivElement | null
     components?: {
         [key: string]: ReactNode;
     }

--- a/es-runtime/src/es-api.ts
+++ b/es-runtime/src/es-api.ts
@@ -168,6 +168,9 @@ export interface RibbonBar {
     claimRibbonPanel: (id: string) => HTMLDivElement | null
     showRibbonTab: (id: string) => HTMLDivElement | null
     hideRibbonTab: (id: string) => HTMLDivElement | null
+    components?: {
+        [key: string]: HTMLElement
+    }
 }
 
 export interface Chrome {


### PR DESCRIPTION
This PR makes some small, non-breaking requests to the ribbon panel implementation of ES. Specifically, it allows for the host application to provide React components to the client extensions via an attribute on the ES object that is passed to the extensions.